### PR TITLE
Feat/photos UI refresh 20250821

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,56 +3,56 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Potos</title>
+  <title>Photos</title>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <header class="header">
-    <div class="brand">
-      <svg class="logo" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <rect x="2" y="6" width="20" height="14" rx="2" ry="2" stroke="currentColor" stroke-width="2" fill="none"></rect>
-        <circle cx="12" cy="13" r="4" stroke="currentColor" stroke-width="2" fill="none"></circle>
-        <path d="M16 3l2 3H6l2-3h8z" stroke="currentColor" stroke-width="2" fill="none" stroke-linejoin="round"></path>
-      </svg>
-      <h1 class="title">Photos</h1>
+    <div class="container">
+      <div class="brand">
+        <svg class="logo" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <rect x="2" y="6" width="20" height="14" rx="2" ry="2" stroke="currentColor" stroke-width="2" fill="none"></rect>
+          <circle cx="12" cy="13" r="4" stroke="currentColor" stroke-width="2" fill="none"></circle>
+          <path d="M16 3l2 3H6l2-3h8z" stroke="currentColor" stroke-width="2" fill="none" stroke-linejoin="round"></path>
+        </svg>
+        <h1 class="title">Photos</h1>
+      </div>
+      <button id="uploadButton" class="icon-btn" aria-label="Upload" title="Upload (U)">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M12 3v12m0 0l-4-4m4 4l4-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          <path d="M4 15v4h16v-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
     </div>
-    <button id="uploadButton" class="icon-btn" aria-label="Upload" title="Upload (U)">
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <path d="M12 3v12m0 0l-4-4m4 4l4-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        <path d="M4 15v4h16v-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-      </svg>
-    </button>
   </header>
   <main>
-    <div id="gallery" class="gallery"></div>
+    <div class="container">
+      <div id="gallery" class="gallery" role="list"></div>
+    </div>
   </main>
-
-<!-- Modal overlay -->
-<div id="modal" class="modal hidden" aria-hidden="true">
-  <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="uploadTitle">
-    <button type="button" id="closeModal" class="close-btn" aria-label="Close" title="Close">&times;</button>
-    <h2 id="uploadTitle">Upload</h2>
-    <form id="uploadForm">
-      <label>
-        <span class="label">Secret Token</span>
-        <input type="password" id="token" name="token" placeholder="Bearer token" autocomplete="off" required>
-      </label>
-      <label>
-        <span class="label">Select Image</span>
-        <input type="file" id="photo" name="photo" accept=".jpg,.jpeg,.png,.gif,.webp" required>
-      </label>
-      <div class="modal-buttons">
-        <button type="submit" class="btn btn-primary">Upload</button>
-        <button type="button" id="cancelUpload" class="btn btn-secondary">Cancel</button>
-      </div>
-    </form>
+  <!-- Modal overlay -->
+  <div id="modal" class="modal hidden" aria-hidden="true">
+    <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="uploadTitle">
+      <button type="button" id="closeModal" class="close-btn" aria-label="Close" title="Close">&times;</button>
+      <h2 id="uploadTitle">Upload</h2>
+      <form id="uploadForm">
+        <label>
+          <span class="label">Secret Token</span>
+          <input type="password" id="token" name="token" placeholder="Bearer token" autocomplete="off" required>
+        </label>
+        <label>
+          <span class="label">Select Image</span>
+          <input type="file" id="photo" name="photo" accept=".jpg,.jpeg,.png,.gif,.webp" required>
+        </label>
+        <div class="modal-buttons">
+          <button type="submit" class="btn btn-primary">Upload</button>
+          <button type="button" id="cancelUpload" class="btn btn-secondary">Cancel</button>
+        </div>
+      </form>
+    </div>
   </div>
-</div>
-
-
   <!-- Toast notification -->
   <div id="toast" class="toast" role="status" aria-live="polite"></div>
-
   <script src="script.js"></script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -9,6 +9,28 @@
   --shadow: rgba(0, 0, 0, 0.1);
   --toast-bg: rgba(50, 50, 50, 0.9);
   --toast-error: #dc3545;
+    /* spacing scale */
+  --space-xxs: 0.25rem;
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+  --space-2xl: 3rem;
+  /* typography scale */
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.25rem;
+  --font-size-xl: 1.5rem;
+  --font-size-2xl: 2rem;
+  /* radii */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  /* container width */
+  --container-max-width: 64rem;
+  --btn-size: 2.5rem;
+  
 }
 
 @media (prefers-color-scheme: dark) {
@@ -39,29 +61,29 @@ body {
 }
 
 .container {
-  max-width: 1000px;
+max-width: var(--container-max-width);
   margin: 0 auto;
-  padding: 1rem 1.5rem;
+padding: var(--space-lg) var(--space-xl);
 }
 
 .header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 1rem;
+  
 }
 
 .title {
-  display: flex;
+display: flex;
   align-items: center;
-  font-size: 1.75rem;
+  font-size: var(--font-size-xl);
   font-weight: 600;
 }
 
 .title .logo {
   display: inline-flex;
-  margin-right: 0.5rem;
-  font-size: 1.5rem;
+  margin-right: var(--space-sm);
+  font-size: var(--font-size-lg);
   color: var(--accent);
 }
 
@@ -69,8 +91,8 @@ body {
   background: var(--accent);
   border: none;
   color: var(--surface);
-  width: 2.5rem;
-  height: 2.5rem;
+  width: var(--btn-size);
+  height: var(--btn-size);
   border-radius: 50%;
   display: flex;
   align-items: center;
@@ -92,13 +114,13 @@ body {
 .gallery {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-  gap: 1rem;
+gap: var(--space-lg);
 }
 
 .gallery img {
   width: 100%;
   height: auto;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   box-shadow: 0 2px 5px var(--shadow);
   object-fit: cover;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -115,6 +137,7 @@ body {
   left: 0;
   width: 100%;
   height: 100%;
+  
   display: none;
   align-items: center;
   justify-content: center;
@@ -126,7 +149,7 @@ body {
 .modal:not(.hidden) {
   display: flex;
 }
-
+var(--space-xl)
 .modal-content {
   background: var(--surface);
   color: var(--text);
@@ -157,7 +180,7 @@ body {
 .modal-content input[type="file"] {
   width: 100%;
   padding: 0.5rem;
-  border: 1px solid #ccc;
+  border: var(--space-md) var(--space-sm) #ccc;
   border-radius: 4px;
   font-size: 1rem;
 }
@@ -170,9 +193,9 @@ body {
 }
 
 .btn {
-  padding: 0.5rem 1rem;
+  padding: var(--space-sm) var(--space-md);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   font-size: 1rem;
   cursor: pointer;
 }


### PR DESCRIPTION
- Fixes the title typo (“Potos” → “Photos”).

- Wraps header + gallery in a responsive .container.

- Adds a11y hooks (e.g., role="list" on the gallery; modal retains dialog roles).

- Introduces CSS custom properties (spacing, font sizes, radii, container width, button size) and refactors styles to use them; adjusts gallery grid gap and header/button sizing.

- Changes are limited to public/index.html and public/styles.css.